### PR TITLE
Modified dark mode functionality for FOUC measures.

### DIFF
--- a/app/Http/Controllers/ThemesController.php
+++ b/app/Http/Controllers/ThemesController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ThemesController extends Controller
+{
+    // ダークモード
+    public function darkMode() {
+        // 現在のダークモード状態を取得。デフォルトは「disabled」
+        $currentMode = session('darkMode', 'disabled');
+        
+        // 現在の状態が「enabled」なら「disabled」に、そうでなければ「enabled」に切り替え
+        $newMode = $currentMode === 'enabled' ? 'disabled' : 'enabled';
+        
+        // セッションに新しいモードを保存
+        session(['darkMode' => $newMode]);
+        
+        // 新しいモードの状態をJSONレスポンスとして返す
+        return response()->json(['darkMode' => $newMode]);
+    }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -63,29 +63,3 @@ body.dark-mode .form-control:focus {
 .wrapper-button {
     margin: 10px; /* ボタン間のスペースを確保 */
 }
-
-/* flexboxを使用する */
-/* 親要素 */
-.flex_test-box {
-    display: flex;
-    justify-content: flex-end;
-    width: 90%;
-}
-
-/* 子要素 */
-.flex_test-item {
-    margin: 10px;
-}
-
-/* Updateが1,Deleteが2,Copyが3で、それを並び替える */
-.flex_test-item:nth-child(1) {
-    order: 2;
-}
-
-.flex_test-item:nth-child(2) {
-    order: 1;
-}
-
-.flex_test-item:nth-child(3) {
-    order: 3;
-}

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -1,31 +1,25 @@
 <template>
   <div>
-    <!-- ダークモード切り替えボタン -->
-    <button @click="toggleDarkMode" style="padding: 10px; background: gray; color: white; border: none; border-radius: 5px;">
-      {{ isDarkMode ? "Light Mode" : "Dark Mode" }}
+    <button @click="toggleDarkMode" class="btn btn-dark">
+      {{ state.darkMode ? 'ライトモード' : 'ダークモード' }}
     </button>
   </div>
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue';
+import { inject } from 'vue';
+import axios from 'axios';
 
-// ダークモード状態を管理
-const isDarkMode = ref(localStorage.getItem('darkMode') === 'enabled');
+// Vue.jsで提供された状態を受け取る
+const state = inject('state');
 
-// ダークモードを切り替える関数
-const toggleDarkMode = () => {
-  isDarkMode.value = !isDarkMode.value;
-  localStorage.setItem('darkMode', isDarkMode.value ? 'enabled' : 'disabled');
-};
-
-// クラスを状態に応じて反映
-watchEffect(() => {
-  const html = document.body;
-  if (isDarkMode.value) {
-    html.classList.add('dark-mode');
-  } else {
-    html.classList.remove('dark-mode');
+// ダークモードの切り替え
+const toggleDarkMode = async () => {
+  try {
+    const response = await axios.post('/theme/toggle');
+    state.darkMode = response.data.darkMode === 'enabled';
+  } catch (error) {
+    console.error('Error toggling dark mode:', error);
   }
-});
+};
 </script>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,14 +1,26 @@
 import './bootstrap';
-
-import { createApp } from 'vue';
+import { createApp, reactive, watchEffect } from 'vue';
 import App from './App.vue';
 
-const app = createApp(App);
+// 初期値の取得
+const appElement = document.getElementById('app');
+const initialDarkMode = appElement.dataset.darkMode === 'enabled';
 
-// ページ読み込み時にダークモードの状態を取得
-const darkModeState = localStorage.getItem('darkMode');
-if (darkModeState === 'enabled') {
+// 状態を管理
+const state = reactive({
+  darkMode: initialDarkMode,
+});
+
+// 状態に応じて`body`タグのクラスを更新
+watchEffect(() => {
+  if (state.darkMode) {
     document.body.classList.add('dark-mode');
-}
+  } else {
+    document.body.classList.remove('dark-mode');
+  }
+});
 
+// Vueアプリケーションのセットアップ
+const app = createApp(App);
+app.provide('state', state);
 app.mount('#app');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Template Creator</title>
-   
+
+    <link rel="preload" href="{{ asset('css/style.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet';">
+
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     
@@ -13,13 +15,10 @@
     
     <!-- Bootstrap Icons CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.5/font/bootstrap-icons.min.css">
-    
-    <!-- Custom CSS -->
-    <link rel="stylesheet" href="{{ asset('css/style.css') }}">
 
     @vite('resources/js/app.js')
 </head>
-<body>
+<body class="{{ session('darkMode') === 'enabled' ? 'dark-mode' : '' }}">
     <div class="mt-3 container">
         <!-- エラーメッセージの領域の高さを固定してスペースを確保 -->
         <div style="height: 10px;">

--- a/resources/views/templates/index.blade.php
+++ b/resources/views/templates/index.blade.php
@@ -2,7 +2,12 @@
 @include('commons.navbar')
 
 @section('content')
-    <div id="app" class="mb-5"></div>
+    <!-- Vue.js アプリケーション -->
+    <div id="app" 
+        data-dark-mode="{{ session('darkMode', 'disabled') }}" 
+        data-csrf="{{ csrf_token() }}">
+    </div>
+
     <h5 class="text-center text-primary">テンプレート作成画面</h5>
     <div class="top">
         <form action="{{ route('templates.store') }}" method="POST">

--- a/resources/views/templates/show.blade.php
+++ b/resources/views/templates/show.blade.php
@@ -2,7 +2,11 @@
 @include('commons.navbar')
 
 @section('content')
-    <div id="app" class="mb-5"></div>
+        <!-- Vue.js アプリケーション -->
+    <div id="app"
+        data-dark-mode="{{ session('darkMode', 'disabled') }}" 
+        data-csrf="{{ csrf_token() }}">
+    </div>
     @if(isset($templates) && count($templates) > 0)
         <h5 class="text-center text-danger">テンプレート一覧</h5>
         <div class="d-flex justify-content-end mt-3 mr-3 ml-3 mb-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,19 +1,15 @@
 <?php
 
 use App\Http\Controllers\TemplatesController;
+use App\Http\Controllers\ThemesController;
 use Illuminate\Support\Facades\Route;
 
 // トップページ
 Route::get('/', [TemplatesController::class, 'index'])
     ->name('templates.index');
 
-Route::post('/theme/toggle', function () {
-    $currentMode = session('darkMode', 'disabled');
-    $newMode = $currentMode === 'enabled' ? 'disabled' : 'enabled';
-    session(['darkMode' => $newMode]);
-
-    return response()->json(['darkMode' => $newMode]);
-})->name('theme.toggle');
+Route::post('/theme/toggle', [ThemesController::class, 'darkMode'])
+    ->name('theme.toggle');
 
 // 認証済みユーザーのためのルートグループ
 Route::middleware(['auth'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,14 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', [TemplatesController::class, 'index'])
     ->name('templates.index');
 
+Route::post('/theme/toggle', function () {
+    $currentMode = session('darkMode', 'disabled');
+    $newMode = $currentMode === 'enabled' ? 'disabled' : 'enabled';
+    session(['darkMode' => $newMode]);
+
+    return response()->json(['darkMode' => $newMode]);
+})->name('theme.toggle');
+
 // 認証済みユーザーのためのルートグループ
 Route::middleware(['auth'])->group(function () {
     


### PR DESCRIPTION
#Overview
In order to counter FOUC countermeasures that were found when the dark mode function was implemented, changes were made to save the dark mode state in the session when the dark mode function is turned on and to manage it on the back end.

#The following files related to the darkmode have been created.
- app/Http/Controller/ThemesController.php

In ThemesController.php, when a button is pressed, the current dark mode state is retrieved from the session, and dark mode is set if the button is not in dark mode, and light mode is set if the button is in dark mode.

#The following files related to the darkmode have been updated.
- routes/web.php
- resources/views/templates/index.blade.php
- resources/views/templates/show.blade.php

In the web.php file, we set up a route corresponding to the controller to save the dark mode to the session.
In the view file, the div tag was modified and a description was added to have the initial state of dark mode when the file is loaded so that if dark mode is applied to the information stored in the session, it is applied immediately.